### PR TITLE
Update croho

### DIFF
--- a/00_download/Download CROHO.R
+++ b/00_download/Download CROHO.R
@@ -1,0 +1,36 @@
+## +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+## R code voor Student Analytics Vrije Universiteit Amsterdam
+## Copyright 2023 VU
+## Web Page: http://www.vu.nl
+## Contact: vu-analytics@vu.nl
+##
+##' *INFO*:
+## 1) ___
+##
+## ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+## View the Duo website where the link to the most recent Croho file can be found.
+link_croho <- rvest::read_html("https://duo.nl/zakelijk/hoger-onderwijs/studentenadministratie/croho.jsp") %>%
+  ## Select all <a> tags containing "ASCI"
+  rvest::html_nodes(css = "a:contains(ASCI)") %>%
+  ## Extract the "href" attribute from these <a> tags to get the link
+  rvest::html_attr("href") %>%
+  ## Prepend the protocol and domain to the link
+  paste0("https://duo.nl", .)
+
+## Determine the Croho network directory
+Croho_network_dir <- "data/00_raw"
+## Determine the location where the zip file will be stored, with today's date in the filename.
+Croho_network_file_path <- paste0(Croho_network_dir, "/", lubridate::ymd(lubridate::today()), "_croho-ascii.zip")
+
+## Download the file to the network drive
+invisible(httr::GET(link_croho, httr::write_disk(Croho_network_file_path, overwrite = TRUE)))
+
+## Unzip the file
+unzip(Croho_network_file_path, files = "CrohoAct.txt", exdir = Croho_network_dir, overwrite = TRUE)
+
+## +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+## CLEAR #######
+## +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+vusa::clear_script_objects()

--- a/01_audit/Inlezen CROHO.R
+++ b/01_audit/Inlezen CROHO.R
@@ -24,10 +24,17 @@
 ## Inlezen documentatie bestand
 CROHO_naming <- read_documentation("Documentatie_CROHO.csv")
 
-file_path <- "data/00_raw/CrohoActueel17-10-2022.xlsx"
+## To be downloaded from DUO
+file_path <- "data/00_raw/CrohoAct.txt"
+
+dfMeta <- read.csv("metadata/data_dictionary_start/Metadata_CROHO.csv")
 
 ## Lees Het crohobestand in
-CROHO <- read_xlsx(file_path)
+CROHO <- LaF::laf_open_fwf(file_path,
+                           column_widths = dfMeta$widths,
+                           column_names = dfMeta$names_croho,
+                           column_types = dfMeta$types
+                          )[,]
 
 
 ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/metadata/data_dictionary_start/Metadata_CROHO.csv
+++ b/metadata/data_dictionary_start/Metadata_CROHO.csv
@@ -1,0 +1,52 @@
+names_croho,types,widths,position
+Brinnummer,character,4,1
+Brinvolgnummer,integer,2,5
+Naam onderwijsinstelling,character,70,7
+Gemeentenaam,character,24,77
+Onderdeel,character,70,101
+Subonderdeel,character,70,171
+Opleidingscode,integer,5,241
+Naam opleiding voluit,character,225,246
+Internationale naam,character,225,471
+Opleidingsvorm,character,8,696
+Datum begin opleiding,character,10,704
+Datum einde instroom,character,10,714
+Datum einde opleiding,character,10,724
+Studielast,integer,4,734
+Grondslag studielast,character,15,738
+Studielast VT,integer,3,753
+Propedeutisch examen,character,3,756
+Eisen te verrichten werkzaamheden,character,3,759
+Bekostiging,character,15,762
+Bekostigingsduur,integer,5,777
+Inschrijving met deficiëntie,character,3,782
+Beroepsvereisten,character,3,785
+Datum accreditatiebesluit/melding,character,10,788
+Datum begin accreditatie,character,10,798
+Datum uitstel tot accreditatie,character,10,808
+Datum einde instroom accreditatie,character,10,818
+Datum vervallen accreditatie,character,10,828
+Datum einde afbouw accreditatie,character,10,838
+Reden uitstel,character,150,848
+Indicatie aanmelding,character,10,998
+Indicatie soort fixus,character,17,1008
+Indicatie decentrale selectie,character,3,1025
+Vervaldatum decentrale selectie,character,10,1028
+Indicatie aanvullende eisen,character,3,1038
+Afwijkende VSL code RASP,character,5,1041
+Code stand record,character,10,1046
+Bekostigingsniveau,character,5,1056
+Relatiesoort,character,20,1061
+BRIN relatie,character,4,1081
+Opl.code relatie,integer,5,1085
+Ind. Intensief progr.,character,3,1090
+Selectie-eisen Intensief progr.,character,3,1093
+Verhoogd coll.geld Intensief progr.,character,3,1096
+Onderwijscapaciteit,integer,4,1099
+Versneld traject,character,3,1103
+Graad,character,20,1106
+Graadtoevoeging,character,80,1126
+Inleverdatum,character,10,1206
+Datum voorwaarden,character,10,1216
+Datum intrekking,character,10,1226
+...51,character,1,1236

--- a/utils/proj_settings/renv.lock
+++ b/utils/proj_settings/renv.lock
@@ -41,6 +41,18 @@
       ],
       "Hash": "a56a6365b3fa73293ea8d084be0d9bb0"
     },
+    "LaF": {
+      "Package": "LaF",
+      "Version": "0.8.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "methods",
+        "utils"
+      ],
+      "Hash": "f6e650a4ea4c8765c612c3fa8de17f92"
+    },
     "Matrix": {
       "Package": "Matrix",
       "Version": "1.5-4.1",


### PR DESCRIPTION
Before the script `Inlezen CROHO.R` read a harcoded path. Furthermore, this path lead to a xlsx file.

However, we should probably download the raw ASCII file and read it in, in order to have the most recent version of the CROHO data.

The following pull request does the following:
 

1. Adds a script to download raw ascii CROHO data.
2. Adds a metadata file on CROHO in order to read the data correctly.
3. Updates the script `Inlezen CROHO.R` script to read the metadata file and raw ASCII file.
4. Adds the LaF package to renv, which is needed to read the raw ASCII file correctly.