### PR TITLE
Use script validation when build is run

### DIFF
--- a/build.R
+++ b/build.R
@@ -13,5 +13,16 @@ sScripts_to_run <- sFolders %>%
    map(., ~paste0(., "/", list.files(.))) %>%
    unlist()
 
+# Create a data frame for script validation
+dfScriptvalidation <- tribble(
+  ~script,
+  sScripts_to_run
+) %>%
+  unnest(c(script))
 
-walk(sScripts_to_run, source)
+## Read the Script validation data in
+##' *Note*: All scripts are run here, it takes a long time
+dfScriptvalidation <- dfScriptvalidation %>%
+  mutate(validation_df = map_dfr(script, safely(~ vusa::validate_script_proj(.x, TRUE)))) %>%
+  unnest_wider(validation_df) %>%
+  unnest_wider(result)


### PR DESCRIPTION
As discussed when running `build.R` we might as well run script validation.

Please check the resulting table, just to be sure!